### PR TITLE
feat: add intersection observer to player

### DIFF
--- a/src/routes/Band.svelte
+++ b/src/routes/Band.svelte
@@ -1,22 +1,40 @@
-<script>
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+
   export let type;
   export let embedUrl;
   export let title;
+
+  let root: any = null;
+  
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        const src = entry.target.getAttribute('data-src') || ''
+        entry.target.setAttribute('src', src)
+        
+        observer.disconnect();
+      }
+    });
+  });
+
+  onMount(() => {
+    observer.observe(root);
+  });
+
+  onDestroy(() => {
+    observer.disconnect();
+  });
+
 </script>
 
 
-{#if type === 'bandcamp'}
-  <iframe 
-    src={embedUrl}
-    class="w-full h-32"
-    {title}
+<iframe
+  bind:this={root}
+  data-src={embedUrl}
+  data-type={type}
+  src=''
+  class="w-full h-32"
+  {title}
   >
-  </iframe>
-{:else if type === 'soundcloud'}
-  <iframe
-    src={embedUrl}
-    class="w-full h-32"
-    {title}
-  >
-  </iframe>
-{/if}
+</iframe>


### PR DESCRIPTION
@codingconcepts if you can get a Netlify preview of this, open the network tab and take a look at "MB Transfered". As you scroll you should see this number get bigger as each player is loaded, only when it's scrolled into the viewport.

It's still a hefty load, but it's better than loading everything all at once. 